### PR TITLE
Adapt to latest @graknlabs_bazel_distribution

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,9 +77,11 @@ graknlabs_build_tools_ci_pip_install()
 # Load Distribution dependencies #
 ##################################
 
-# TODO: rename the macro we load here to deploy_github_dependencies
-load("@graknlabs_bazel_distribution//github:dependencies.bzl", "github_dependencies_for_deployment")
-github_dependencies_for_deployment()
+load("@graknlabs_bazel_distribution//github:dependencies.bzl", "tcnksm_ghr")
+tcnksm_ghr()
+
+load("@graknlabs_bazel_distribution//common:dependencies.bzl", "bazelbuild_rules_pkg")
+bazelbuild_rules_pkg()
 
 
 #####################################

--- a/config/rpm/grakn-bin.spec
+++ b/config/rpm/grakn-bin.spec
@@ -21,6 +21,7 @@ Grakn Core (server) - description
 %install
 mkdir -p %{buildroot}
 tar -xvf {_grakn-bin-rpm-tar.tar.gz} -C %{buildroot}
+rm -fv {_grakn-core-server-rpm-tar.tar.gz}
 
 %files
 

--- a/config/rpm/grakn-bin.spec
+++ b/config/rpm/grakn-bin.spec
@@ -21,7 +21,7 @@ Grakn Core (server) - description
 %install
 mkdir -p %{buildroot}
 tar -xvf {_grakn-bin-rpm-tar.tar.gz} -C %{buildroot}
-rm -fv {_grakn-core-server-rpm-tar.tar.gz}
+rm -fv {_grakn-bin-rpm-tar.tar.gz}
 
 %files
 


### PR DESCRIPTION
## What is the goal of this PR?

Newest changes in `bazel-distribution` (graknlabs/bazel-distribution#181) are backwards-incompatible.

## What are the changes implemented in this PR?

- Uses workspace macros from most recent `bazel-distribution` version