### PR TITLE
Refactor how version is provided to deployment rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,11 +67,10 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run: echo 0.0.0-$CIRCLE_SHA1 > VERSION && cat VERSION
       - run: |
           export DEPLOY_APT_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_APT_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //bin:deploy-apt -- snapshot
+          bazel run --define version=$(git rev-parse HEAD) //bin:deploy-apt -- snapshot
 
   deploy-rpm-snapshot:
     machine: true
@@ -80,11 +79,10 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run: sudo apt-get update && sudo apt-get install rpm
-      - run: echo 0.0.0_$CIRCLE_SHA1 > VERSION && cat VERSION
       - run: |
           export DEPLOY_RPM_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_RPM_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //bin:deploy-rpm -- snapshot
+          bazel run --define version=$(git rev-parse HEAD) //bin:deploy-rpm -- snapshot
 
   sync-dependencies-snapshot:
     machine: true
@@ -119,7 +117,7 @@ jobs:
           bazel run @graknlabs_build_tools//ci:release-notes -- common $(cat VERSION) ./RELEASE_TEMPLATE.md
       - run: |
           export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-          bazel run //:deploy-github -- $CIRCLE_SHA1
+          bazel run --define version=$(cat VERSION) //:deploy-github -- $CIRCLE_SHA1
 
   deploy-apt:
     machine: true
@@ -131,7 +129,7 @@ jobs:
       - run: |
           export DEPLOY_APT_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_APT_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //bin:deploy-apt -- release
+          bazel run --define version=$(cat VERSION) //bin:deploy-apt -- release
 
   deploy-rpm:
     machine: true
@@ -140,11 +138,10 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run: sudo apt-get update && sudo apt-get install rpm
-      - run: cat VERSION
       - run: |
           export DEPLOY_RPM_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_RPM_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //bin:deploy-rpm -- release
+          bazel run --define version=$(cat VERSION) //bin:deploy-rpm -- release
 
   sync-dependencies-release:
     machine: true

--- a/BUILD
+++ b/BUILD
@@ -25,5 +25,4 @@ deploy_github(
     title = "Grakn Common",
     title_append_version = True,
     release_description = "//:RELEASE_TEMPLATE.md",
-    version_file = "//:VERSION"
 )

--- a/bin/BUILD
+++ b/bin/BUILD
@@ -47,7 +47,6 @@ assemble_apt(
     package_name = "grakn-bin",
     maintainer = "Grakn Labs <community@grakn.ai>",
     description = "Grakn Core (binaries)",
-    version_file = "//:VERSION",
     archives = [":assemble-bash-targz"],
     installation_dir = "/opt/grakn/core/",
     empty_dirs = [
@@ -75,7 +74,6 @@ assemble_rpm(
     name = "assemble-linux-rpm",
     package_name = "grakn-bin",
     installation_dir = "/opt/grakn/core/",
-    version_file = "//:VERSION",
     spec_file = "//config/rpm:grakn-bin.spec",
     empty_dirs = [
         "var/log/grakn/",


### PR DESCRIPTION
## What is the goal of this PR?

Adapt `@graknlabs_common` to latest changes in bazel-distribution (in particular, graknlabs/bazel-distribution#150)

## What are the changes implemented in this PR?

Instead of supplying `version_file` everywhere, use `--define version=<>` as a Bazel argument to supply version.

