### PR TITLE
Integrate grakn core Common utils

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,16 @@ jobs:
       - run-bazel-rbe:
           command: bazel build //...
 
+  build-checkstyle:
+    machine: true
+    working_directory: ~/common
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: bazel run @graknlabs_build_tools//checkstyle:test-coverage
+      - run-bazel-rbe:
+          command: bazel test $(bazel query 'kind(checkstyle_test, //...)')
+
   build-analysis:
     machine: true
     working_directory: ~/common
@@ -60,6 +70,17 @@ jobs:
           SONARCLOUD_CODE_ANALYSIS_CREDENTIAL=$SONARCLOUD_CREDENTIAL \
             bazel run @graknlabs_build_tools//sonarcloud:code-analysis -- \
             --project-key graknlabs_common --branch=$CIRCLE_BRANCH --commit-id=$CIRCLE_SHA1
+
+  deploy-maven-snapshot:
+    machine: true
+    working_directory: ~/common
+    steps:
+      - checkout
+      - install-bazel-linux-rbe
+      - run: |
+          export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
+          export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
+          bazel run --define version=$(git rev-parse HEAD) //:deploy-maven -- snapshot
 
   deploy-apt-snapshot:
     machine: true
@@ -119,6 +140,17 @@ jobs:
           export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
           bazel run --define version=$(cat VERSION) //:deploy-github -- $CIRCLE_SHA1
 
+  deploy-maven-release:
+    machine: true
+    working_directory: ~/common
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: |
+          export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
+          export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
+          bazel run --define version=$(cat VERSION) //:deploy-maven -- release
+
   deploy-apt:
     machine: true
     working_directory: ~/common
@@ -167,6 +199,10 @@ workflows:
           filters:
             branches:
               ignore: common-release-branch
+      - build-checkstyle:
+          filters:
+            branches:
+              only: master
       - build-analysis:
           filters:
             branches:
@@ -178,6 +214,7 @@ workflows:
           requires:
             - build
             - build-analysis
+            - build-checkstyle
       - deploy-rpm-snapshot:
           filters:
             branches:
@@ -185,6 +222,15 @@ workflows:
           requires:
             - build
             - build-analysis
+            - build-checkstyle
+      - deploy-maven-snapshot:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - build-checkstyle
+            - build-checkstyle
       - sync-dependencies-snapshot:
           filters:
             branches:
@@ -192,6 +238,7 @@ workflows:
           requires:
             - deploy-apt-snapshot
             - deploy-rpm-snapshot
+            - deploy-maven-snapshot
       - release-approval:
           filters:
             branches:
@@ -212,6 +259,12 @@ workflows:
           filters:
             branches:
               only: common-release-branch
+      - deploy-maven-release:
+        filters:
+          branches:
+            only: client-java-release-branch
+        requires:
+          - deploy-approval
       - deploy-apt:
           filters:
             branches:
@@ -231,6 +284,7 @@ workflows:
           requires:
             - deploy-apt
             - deploy-rpm
+            - deploy-maven-release
       - release-cleanup:
           filters:
             branches:

--- a/BUILD
+++ b/BUILD
@@ -18,6 +18,9 @@
 
 exports_files(["VERSION"], visibility = ["//visibility:public"])
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
+load("@graknlabs_build_tools//distribution/maven:rules.bzl", "deploy_maven", "assemble_maven")
+load("@graknlabs_build_tools//checkstyle:rules.bzl", "checkstyle_test")
+
 
 java_library(
     name = "common",
@@ -32,4 +35,26 @@ deploy_github(
     title = "Grakn Common",
     title_append_version = True,
     release_description = "//:RELEASE_TEMPLATE.md",
+)
+
+assemble_maven(
+    name = "assemble-maven",
+    target = ":common",
+    package = "common",
+    workspace_refs = "@graknlabs_common_workspace_refs//:refs.json",
+    project_name = "Grakn Common",
+    project_description = "Grakn Common classes and tools",
+    project_url = "https://github.com/graknlabs/common",
+    scm_url = "https://github.com/graknlabs/common",
+)
+
+deploy_maven(
+    name = "deploy-maven",
+    target = ":assemble-maven",
+)
+
+
+checkstyle_test(
+    name = "checkstyle",
+    targets = [":common"],
 )

--- a/BUILD
+++ b/BUILD
@@ -19,6 +19,13 @@
 exports_files(["VERSION"], visibility = ["//visibility:public"])
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
 
+java_library(
+    name = "common",
+    srcs = glob(["**/*.java"]),
+    visibility = ["//visibility:public"],
+    tags = ["maven_coordinates=io.grakn.common:grakn-common:{pom_version}"],
+)
+
 deploy_github(
     name = "deploy-github",
     deployment_properties = "//:deployment.properties",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -91,3 +91,9 @@ bazelbuild_rules_pkg()
 # TODO: Figure out why this cannot be loaded at earlier at the top of the file
 load("@com_github_google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")
 google_common_workspace_rules()
+
+# Generate a JSON document of commit hashes of all external workspace dependencies
+load("@graknlabs_bazel_distribution//common:rules.bzl", "workspace_refs")
+workspace_refs(
+    name = "graknlabs_common_workspace_refs"
+)

--- a/util/Collections.java
+++ b/util/Collections.java
@@ -1,0 +1,68 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2019 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class Collections {
+
+    @SafeVarargs
+    public static <K, V> Map<K, V> map(Pair<K, V>... pairs) {
+        Map<K, V> map = new HashMap<>();
+        for(Pair<K, V> tuple : pairs) {
+            map.put(tuple.first(), tuple.second());
+        }
+        return java.util.Collections.unmodifiableMap(map);
+    }
+
+    @SafeVarargs
+    public static <T> Set<T> set(T... elements) {
+        return set(Arrays.asList(elements));
+    }
+
+    public static <T> Set<T> set(Collection<T> elements) {
+        Set<T> set = new HashSet<>(elements);
+        return java.util.Collections.unmodifiableSet(set);
+    }
+
+    @SafeVarargs
+    public static <T> List<T> list(T... elements) {
+        return list(Arrays.asList(elements));
+    }
+
+    public static <T> List<T> list(Collection<T> elements) {
+        List<T> list = new ArrayList<>(elements);
+        return java.util.Collections.unmodifiableList(list);
+    }
+
+    public static <A, B> Pair<A, B> pair(A first, B second) {
+        return new Pair<>(first, second);
+    }
+
+    public static <A, B, C> Triple<A, B, C> triple(A first, B second, C third) {
+        return new Triple<>(first, second, third);
+    }
+}

--- a/util/Pair.java
+++ b/util/Pair.java
@@ -1,0 +1,60 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2019 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+
+package util;
+
+import java.util.AbstractMap;
+
+/**
+ *
+ * <p>
+ * Convenience pair class wrapping a SimpleImmutableEntry object.
+ * </p>
+ *
+ * @param <K> key type
+ * @param <V> value type
+ *
+ *
+ */
+public class Pair<K, V> {
+
+    private final AbstractMap.SimpleImmutableEntry<K, V> data;
+
+    public Pair(K key, V value){
+        data = new AbstractMap.SimpleImmutableEntry<>(key, value);
+    }
+
+    @Override
+    public int hashCode(){ return data.hashCode();}
+
+    @Override
+    public String toString(){ return data.toString();}
+
+    @Override
+    public boolean equals(Object obj){
+        if (obj == null || this.getClass() != obj.getClass()) return false;
+        if (obj == this) return true;
+        Pair p = (Pair) obj;
+        return data.equals(p.data);
+    }
+
+    public K first(){ return data.getKey();}
+    public V second(){ return data.getValue();}
+}

--- a/util/Triple.java
+++ b/util/Triple.java
@@ -1,0 +1,68 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2019 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package util;
+
+import java.util.Objects;
+
+public class Triple<A, B, C> {
+
+    private A first;
+    private B second;
+    private C third;
+
+    public Triple(A first, B second, C third) {
+        this.first = first;
+        this.second = second;
+        this.third = third;
+    }
+
+    public A first() {
+        return first;
+    }
+
+    public B second() {
+        return second;
+    }
+
+    public C third() {
+        return third;
+    }
+
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+
+        Triple<?, ?, ?> other = (Triple) obj;
+        return (Objects.equals(this.first, other.first) &&
+                    Objects.equals(this.second, other.second) &&
+                    Objects.equals(this.third, other.third));
+    }
+
+    public int hashCode() {
+        int h = 1;
+        h *= 1000003;
+        h ^= this.first.hashCode();
+        h *= 1000003;
+        h ^= this.second.hashCode();
+        h *= 1000003;
+        h ^= this.third.hashCode();
+
+        return h;
+    }
+}


### PR DESCRIPTION
1. Move Grakn core's re-usable `common` utils to this repository, notably `collections`, `pair` and `triple` classes.
2. Add `common` functionality to release maven snapshots and releases