### PR TITLE
Change package definitions

### DIFF
--- a/util/Collections.java
+++ b/util/Collections.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package util;
+package grakn.common.util;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/util/Pair.java
+++ b/util/Pair.java
@@ -18,7 +18,7 @@
  */
 
 
-package util;
+package grakn.common.util;
 
 import java.util.AbstractMap;
 

--- a/util/Triple.java
+++ b/util/Triple.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package util;
+package grakn.common.util;
 
 import java.util.Objects;
 


### PR DESCRIPTION
Change the package `util` to be `grakn.core.util` to reflect the common naming scheme across Grakn packages.