### PR TITLE
Use Github credential for release-cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: git push --delete origin common-release-branch
+      - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/graknlabs/common common-release-branch
 
 workflows:
   common:


### PR DESCRIPTION
## What is the goal of this PR?

Use GitHub credential for release-cleanup. This removes the need for adding an additional SSH key to CircleCI.