### PR TITLE
Assemble maven from bazel_distribution

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -17,7 +17,8 @@
 
 exports_files(["VERSION"], visibility = ["//visibility:public"])
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
-load("@graknlabs_dependencies//distribution/maven:rules.bzl", "deploy_maven", "assemble_maven")
+load("@graknlabs_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven")
+load("@graknlabs_dependencies//library/maven:artifacts.bzl", "maven_overrides", maven_overrides_org = "artifacts")
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
 
@@ -47,6 +48,7 @@ assemble_maven(
     target = ":common",
     package = "common",
     workspace_refs = "@graknlabs_common_workspace_refs//:refs.json",
+    version_overrides = maven_overrides(maven_overrides_org),
     project_name = "Grakn Common",
     project_description = "Grakn Common classes and tools",
     project_url = "https://github.com/graknlabs/common",
@@ -56,6 +58,7 @@ assemble_maven(
 deploy_maven(
     name = "deploy-maven",
     target = ":assemble-maven",
+    deployment_properties = "@graknlabs_dependencies//distribution:deployment.properties",
 )
 
 checkstyle_test(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -64,11 +64,15 @@ sonarcloud_dependencies()
 load("@graknlabs_dependencies//tool/unuseddeps:deps.bzl", unuseddeps_deps = "deps")
 unuseddeps_deps()
 
-#####################################################################
-# Load @graknlabs_bazel_distribution from (@graknlabs_dependencies) #
-#####################################################################
+
 load("@graknlabs_dependencies//distribution:deps.bzl", distribution_deps = "deps")
 distribution_deps()
+######################################
+# Load @graknlabs_bazel_distribution #
+######################################
+
+load("//dependencies/graknlabs:repositories.bzl", "graknlabs_bazel_distribution")
+graknlabs_bazel_distribution()
 
 pip3_import(
     name = "graknlabs_bazel_distribution_pip",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -64,13 +64,12 @@ sonarcloud_dependencies()
 load("@graknlabs_dependencies//tool/unuseddeps:deps.bzl", unuseddeps_deps = "deps")
 unuseddeps_deps()
 
-
 load("@graknlabs_dependencies//distribution:deps.bzl", distribution_deps = "deps")
 distribution_deps()
+
 ######################################
 # Load @graknlabs_bazel_distribution #
 ######################################
-
 load("//dependencies/graknlabs:repositories.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()
 

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -18,18 +18,16 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def graknlabs_bazel_distribution():
-    native.local_repository(
+    git_repository(
         name = "graknlabs_bazel_distribution",
-        path = "../bazel-distribution",
+        remote = "https://github.com/graknlabs/bazel-distribution",
+        commit = "30e30cec9e3fe4821103cafbd240ee9862e262ea" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
     )
 
+
 def graknlabs_dependencies():
-#    git_repository(
-#        name = "graknlabs_dependencies",
-#        remote = "https://github.com/graknlabs/dependencies",
-#        commit = "df4ebc603e1ef7fedc5bac9bc81b77905d4fe067", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
-#    )
-    native.local_repository(
+    git_repository(
         name = "graknlabs_dependencies",
-        path = "../dependencies",
+        remote = "https://github.com/graknlabs/dependencies",
+        commit = "07127f135b7f3a1f9a18ab44aba69fa0169df1dc", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -17,9 +17,19 @@
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
+def graknlabs_bazel_distribution():
+    native.local_repository(
+        name = "graknlabs_bazel_distribution",
+        path = "../bazel-distribution",
+    )
+
 def graknlabs_dependencies():
-    git_repository(
+#    git_repository(
+#        name = "graknlabs_dependencies",
+#        remote = "https://github.com/graknlabs/dependencies",
+#        commit = "df4ebc603e1ef7fedc5bac9bc81b77905d4fe067", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+#    )
+    native.local_repository(
         name = "graknlabs_dependencies",
-        remote = "https://github.com/graknlabs/dependencies",
-        commit = "df4ebc603e1ef7fedc5bac9bc81b77905d4fe067", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        path = "../dependencies",
     )


### PR DESCRIPTION
## What is the goal of this PR?
Following the implemation of https://github.com/graknlabs/bazel-distribution/pull/248, we can directly depend on `bazel_distribution` for `assemble-maven` and `deploy-maven` rules, and no longer use `graknlabs_dependencies` for this.



## What are the changes implemented in this PR?
* use new implemetatnion of `assemble-maven` with argument for maven overrides