### PR TITLE
Fix Grakn execution script

### DIFF
--- a/binary/grakn
+++ b/binary/grakn
@@ -53,7 +53,7 @@ elif [ "$1" = "console" ]; then
     if [ -f "${CONSOLE_JAR_FILENAME}" ]; then
         SERVICE_LIB_CP="console/services/lib/*"
         CLASSPATH="${GRAKN_HOME}/${SERVICE_LIB_CP}:${GRAKN_HOME}/console/conf/"
-	# exec replaces current shell process with java so no commands besides this one will ever get executed
+	# exec replaces current shell process with java so no commands after this one will ever get executed
         exec java ${CONSOLE_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" grakn.console.GraknConsole "$@"
     else
         echo "Grakn Core Console is not included in this Grakn distribution."
@@ -64,7 +64,7 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
     if [[ -f "${SERVER_JAR_FILENAME}" ]]; then
         LIB_CP="server/lib/*"
         CLASSPATH="${GRAKN_HOME}/${LIB_CP}:${GRAKN_HOME}/server/conf/"
-	# exec replaces current shell process with java so no commands besides this one will ever get executed
+	# exec replaces current shell process with java so no commands after this one will ever get executed
         exec java ${GRAKN_DAEMON_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dstorage.javaopts="${STORAGE_JAVAOPTS}" -Dserver.javaopts="${SERVER_JAVAOPTS}" grakn.core.server.GraknServer "${@:2}"
     else
         echo "Grakn Core Server is not included in this Grakn distribution."

--- a/binary/grakn
+++ b/binary/grakn
@@ -53,6 +53,7 @@ elif [ "$1" = "console" ]; then
     if [ -f "${CONSOLE_JAR_FILENAME}" ]; then
         SERVICE_LIB_CP="console/services/lib/*"
         CLASSPATH="${GRAKN_HOME}/${SERVICE_LIB_CP}:${GRAKN_HOME}/console/conf/"
+	# exec replaces current shell process with java so no commands besides this one will ever get executed
         exec java ${CONSOLE_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" grakn.console.GraknConsole "$@"
     else
         echo "Grakn Core Console is not included in this Grakn distribution."
@@ -63,6 +64,7 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
     if [[ -f "${SERVER_JAR_FILENAME}" ]]; then
         LIB_CP="server/lib/*"
         CLASSPATH="${GRAKN_HOME}/${LIB_CP}:${GRAKN_HOME}/server/conf/"
+	# exec replaces current shell process with java so no commands besides this one will ever get executed
         exec java ${GRAKN_DAEMON_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dstorage.javaopts="${STORAGE_JAVAOPTS}" -Dserver.javaopts="${SERVER_JAVAOPTS}" grakn.core.server.GraknServer "${@:2}"
     else
         echo "Grakn Core Server is not included in this Grakn distribution."
@@ -76,4 +78,3 @@ else
     exit 1
 fi
 
-exit $?

--- a/binary/grakn
+++ b/binary/grakn
@@ -53,7 +53,7 @@ elif [ "$1" = "console" ]; then
     if [ -f "${CONSOLE_JAR_FILENAME}" ]; then
         SERVICE_LIB_CP="console/services/lib/*"
         CLASSPATH="${GRAKN_HOME}/${SERVICE_LIB_CP}:${GRAKN_HOME}/console/conf/"
-        java ${CONSOLE_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" grakn.console.GraknConsole "$@"
+        exec java ${CONSOLE_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" grakn.console.GraknConsole "$@"
     else
         echo "Grakn Core Console is not included in this Grakn distribution."
         echo "You may want to install Grakn Core Console or Grakn Core (all)."
@@ -63,7 +63,7 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
     if [[ -f "${SERVER_JAR_FILENAME}" ]]; then
         LIB_CP="server/lib/*"
         CLASSPATH="${GRAKN_HOME}/${LIB_CP}:${GRAKN_HOME}/server/conf/"
-        java ${GRAKN_DAEMON_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dstorage.javaopts="${STORAGE_JAVAOPTS}" -Dserver.javaopts="${SERVER_JAVAOPTS}" grakn.core.server.GraknServer "${@:2}"
+        exec java ${GRAKN_DAEMON_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dstorage.javaopts="${STORAGE_JAVAOPTS}" -Dserver.javaopts="${SERVER_JAVAOPTS}" grakn.core.server.GraknServer "${@:2}"
     else
         echo "Grakn Core Server is not included in this Grakn distribution."
         echo "You may want to install Grakn Core Server or Grakn Core (all)."


### PR DESCRIPTION
## What is the goal of this PR?

Fix #29

Currently, starting Grakn Server (or Grakn Console) starts *two* processes (`zsh` is the shell from where you've unpacked Grakn and starting it):

```
    PID TTY          TIME CMD
 114591 pts/0    00:00:02 zsh
 164980 pts/0    00:00:00  \_ bash
 164996 pts/0    00:00:02  |   \_ java
```

This PR makes Grakn the real foreground process:
```
    PID TTY          TIME CMD
 114591 pts/0    00:00:02 zsh
 165363 pts/0    00:00:02  \_ java
```

This prevents the situation where you do `./grakn server &`, kill the process but Grakn continues running.

## What are the changes implemented in this PR?

Prefix spawning `java` process with `exec` so it replaces the script it is in.