### PR TITLE
Use grabl status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Grakn Common
 
-[![CircleCI](https://circleci.com/gh/graknlabs/common/tree/master.svg?style=shield)](https://circleci.com/gh/graknlabs/common/tree/master)
+[![Grabl](https://grabl.io/api/status/graknlabs/common/badge.svg)](https://grabl.io/graknlabs/common)
 
 Grakn Labs common libraries and scripts reused across @graknlabs repositories.


### PR DESCRIPTION
## What is the goal of this PR?

Use grabl status badge instead of circle CI since circle CI project is already removed.

