### PR TITLE
Add debug mode to Grakn executable (shell only)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @haikalpribadi @flyingsilverfin
+* @haikalpribadi @flyingsilverfin @lolski

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @haikalpribadi @flyingsilverfin @lolski
+*        @haikalpribadi @flyingsilverfin
+/binary  @lolski

--- a/binary/grakn
+++ b/binary/grakn
@@ -24,7 +24,7 @@ GRAKN_HOME=$(cd "$(dirname "${path}")" && pwd -P)
 GRAKN_CONFIG="server/conf/grakn.properties"
 
 CONSOLE_JAR_FILENAME=(${GRAKN_HOME}/console/services/lib/io-grakn-console-grakn-console*.jar) # TODO: remove 'services/' in 2.0
-SERVER_JAR_FILENAME=(${GRAKN_HOME}/server/lib/io-grakn-core-grakn-server*.jar)
+SERVER_JAR_FILENAME=(${GRAKN_HOME}/server/lib/common/io-grakn-core-grakn-server*.jar)
 
 # ================================================
 # common helper functions

--- a/binary/grakn
+++ b/binary/grakn
@@ -30,13 +30,13 @@ SERVER_JAR_FILENAME=(${GRAKN_HOME}/server/lib/io-grakn-core-grakn-server*.jar)
 # common helper functions
 # ================================================
 exit_if_java_not_found() {
-  which "${JAVA_BIN}" > /dev/null
-  exit_code=$?
+    which "${JAVA_BIN}" > /dev/null
+    exit_code=$?
 
-  if [[ $exit_code -ne 0 ]]; then
-    echo "Java is not installed on this machine. Grakn needs Java 1.8 in order to run."
-    exit 1
-  fi
+    if [[ $exit_code -ne 0 ]]; then
+        echo "Java is not installed on this machine. Grakn needs Java 1.8 in order to run."
+        exit 1
+    fi
 }
 
 # =============================================
@@ -63,10 +63,23 @@ elif [ "$1" = "console" ]; then
     fi
 elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
     if [[ -f "${SERVER_JAR_FILENAME}" ]]; then
-        LIB_CP="server/lib/*"
-        CLASSPATH="${GRAKN_HOME}/${LIB_CP}:${GRAKN_HOME}/server/conf/"
-    # exec replaces current shell process with java so no commands after this one will ever get executed
-        exec java ${GRAKN_DAEMON_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dstorage.javaopts="${STORAGE_JAVAOPTS}" -Dserver.javaopts="${SERVER_JAVAOPTS}" grakn.core.server.GraknServer "${@:2}"
+        while [[ "$#" -gt 0 ]]; do
+            case $1 in
+                --debug) DEBUG=yes; shift ;;
+            esac
+            shift
+        done
+        LIB_COMMON="server/lib/common/*"
+        CLASSPATH="${GRAKN_HOME}/server/conf/:${GRAKN_HOME}/${LIB_COMMON}"
+        # exec replaces current shell process with java so no commands after these ones will ever get executed
+        if [ $DEBUG ]; then
+            echo "Running Grakn Core Server in debug mode."
+            CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/dev/*"
+            exec java ${GRAKN_DAEMON_JAVAOPTS} -ea -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dstorage.javaopts="${STORAGE_JAVAOPTS}" -Dserver.javaopts="${SERVER_JAVAOPTS}" grakn.core.server.GraknServer "${@:2}"
+        else
+            CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/prod/*"
+            exec java ${GRAKN_DAEMON_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dstorage.javaopts="${STORAGE_JAVAOPTS}" -Dserver.javaopts="${SERVER_JAVAOPTS}" grakn.core.server.GraknServer "${@:2}"
+        fi
     else
         echo "Grakn Core Server is not included in this Grakn distribution."
         echo "You may want to install Grakn Core Server or Grakn Core (all)."

--- a/binary/grakn.bat
+++ b/binary/grakn.bat
@@ -35,7 +35,8 @@ if "%1" == "" goto missingargument
 
 if "%1" == "console" goto startconsole
 
-if "%1" == "server" goto startserver
+if "%1" == "server"  goto startserver
+if "%1" == "version" goto startserver
 
 echo   Invalid argument: %1. Possible commands are:
 echo   Server:          grakn server [--help]
@@ -64,9 +65,9 @@ if exist .\console\services\lib\io-grakn-console-grakn-console-*.jar (
 
 :startserver
 
-set "G_CP=%GRAKN_HOME%\server\conf\;%GRAKN_HOME%\server\services\lib\*"
+set "G_CP=%GRAKN_HOME%\server\conf\;%GRAKN_HOME%\server\lib\common\*;%GRAKN_HOME%\server\lib\prod\*"
 if exist .\server\services\lib\io-grakn-core-grakn-server-*.jar (
-  java %GRAKN_DAEMON_JAVAOPTS% -cp "%G_CP%" -Dgrakn.dir="%GRAKN_HOME%" -Dgrakn.conf="%GRAKN_HOME%\%GRAKN_CONFIG%" -Dstorage.javaopts="%STORAGE_JAVAOPTS%" -Dserver.javaopts="%SERVER_JAVAOPTS%" grakn.core.daemon.GraknDaemon %*
+  java %GRAKN_DAEMON_JAVAOPTS% -cp "%G_CP%" -Dgrakn.dir="%GRAKN_HOME%" -Dgrakn.conf="%GRAKN_HOME%\%GRAKN_CONFIG%" -Dstorage.javaopts="%STORAGE_JAVAOPTS%" -Dserver.javaopts="%SERVER_JAVAOPTS%" grakn.core.server.GraknServer %*
   goto exit
 ) else (
   echo Grakn Core Server is not included in this Grakn distribution^.

--- a/binary/grakn.bat
+++ b/binary/grakn.bat
@@ -66,7 +66,7 @@ if exist .\console\services\lib\io-grakn-console-grakn-console-*.jar (
 :startserver
 
 set "G_CP=%GRAKN_HOME%\server\conf\;%GRAKN_HOME%\server\lib\common\*;%GRAKN_HOME%\server\lib\prod\*"
-if exist .\server\services\lib\io-grakn-core-grakn-server-*.jar (
+if exist .\server\lib\common\io-grakn-core-grakn-server-*.jar (
   java %GRAKN_DAEMON_JAVAOPTS% -cp "%G_CP%" -Dgrakn.dir="%GRAKN_HOME%" -Dgrakn.conf="%GRAKN_HOME%\%GRAKN_CONFIG%" -Dstorage.javaopts="%STORAGE_JAVAOPTS%" -Dserver.javaopts="%SERVER_JAVAOPTS%" grakn.core.server.GraknServer %*
   goto exit
 ) else (


### PR DESCRIPTION
## What is the goal of this PR?

To give users (and ourselves!) a convenient way of running Grakn in debug mode, where Grakn and RocksDB assertions are enabled.

## What are the changes implemented in this PR?

Add debug mode to Grakn executable (shell only, so not Windows).
