### PR TITLE
Fix Grakn failing to start in Linux

### DIFF
--- a/binary/grakn
+++ b/binary/grakn
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # Copyright (C) 2020 Grakn Labs
 #
@@ -14,8 +15,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-
-#!/bin/bash
 
 # Grakn global variables
 JAVA_BIN=java

--- a/binary/grakn
+++ b/binary/grakn
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Grakn global variables
 JAVA_BIN=java

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -20,6 +20,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
-        remote = "https://github.com/alexjpwalker/dependencies",
-        commit = "ef5bd2fa238974f05f8bf2201fe84046aee9de6a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        remote = "https://github.com/graknlabs/dependencies",
+        commit = "91f7662e57911a21e84dc8e1e4ddb734defb6c32", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -20,6 +20,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
-        remote = "https://github.com/graknlabs/dependencies",
-        commit = "34f55e21fcfd942e5919f11c6255512b3590af73", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        remote = "https://github.com/alexjpwalker/dependencies",
+        commit = "ef5bd2fa238974f05f8bf2201fe84046aee9de6a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )


### PR DESCRIPTION
## What is the goal of this PR?

To fix Grakn failing to start in Linux.

## What are the changes implemented in this PR?

Move the directive `#!/usr/bin/env bash` to line 1 of `grakn`. Linux ignores it if it's not on line 1.