### PR TITLE
Extend NamedThreadFactory with arbitrary prefix

### DIFF
--- a/concurrent/NamedThreadFactory.java
+++ b/concurrent/NamedThreadFactory.java
@@ -26,8 +26,16 @@ public class NamedThreadFactory implements ThreadFactory {
     private final AtomicLong index = new AtomicLong(0);
     private final String prefix;
 
+    public NamedThreadFactory(String prefix) {
+        this.prefix = prefix + "::";
+    }
+
     public NamedThreadFactory(Class<?> clazz, String function) {
-        this.prefix = clazz.getSimpleName() + "::" + function + "::";
+        this(clazz.getSimpleName() + "::" + function);
+    }
+
+    public static NamedThreadFactory create(String prefix) {
+        return new NamedThreadFactory(prefix);
     }
 
     public static NamedThreadFactory create(Class<?> clazz, String function) {


### PR DESCRIPTION
## What is the goal of this PR?

In cluster, we need to create thread factory with prefix based on functionality instead of class name and function. E.g. we want `event-loop::0`, `client-rpc::1` and so on.

## What are the changes implemented in this PR?

Add a constructor to `NamedThreadFactory` to allow providing an arbitrary prefix.
