### PR TITLE
Add grakn-node-test rule

### DIFF
--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -17,6 +17,8 @@
 
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
+exports_files(["cucumber_test.sh"])
+
 java_library(
     name = "grakn-setup",
     srcs = [

--- a/test/server/cucumber_test.sh
+++ b/test/server/cucumber_test.sh
@@ -1,0 +1,1 @@
+node ./node_modules/.bin/cucumber-js ./external/graknlabs_behaviour/**/*.feature -require-module ts-node/register --require './**/*.ts'

--- a/test/server/rules.bzl
+++ b/test/server/rules.bzl
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-def grakn_test(grakn_artifact = None,
+def grakn_java_test(grakn_artifact = None,
                deps = [],
                classpath_resources = [],
                data = [],
@@ -42,3 +42,14 @@ def grakn_test(grakn_artifact = None,
         **kwargs
     )
 
+def grakn_node_test (name = "", feature_label = "@graknlabs_behaviour//"):
+    native.sh_test (
+        name = name,
+        data = [
+            "//:node_modules",
+            "//:package.json",
+            ":behaviour",
+            feature_label,
+        ],
+        srcs = ["cucumber_test.sh"],
+    )

--- a/test/server/rules.bzl
+++ b/test/server/rules.bzl
@@ -51,5 +51,5 @@ def grakn_node_test (name = "", feature_label = "@graknlabs_behaviour//"):
             ":behaviour",
             feature_label,
         ],
-        srcs = ["cucumber_test.sh"],
+        srcs = ["@graknlabs_common//test/server:cucumber_test.sh"],
     )


### PR DESCRIPTION
## What is the goal of this PR?

For testing purposes, client-nodejs needs to have the ability to run cucumber BDD tests in a Bazel Test environment. 

## What are the changes implemented in this PR?

- Renames existing grakn_test rule to a more descriptive "grakn_java_test"
- Creates a new bazel rule, grakn_node_test, that wraps the native sh_test rule.
- Introduces (and exports) cucumber_test.sh, which invokes the entry point for cucumberjs.
