### PR TITLE
Fix console argument off by one bug

### DIFF
--- a/binary/grakn
+++ b/binary/grakn
@@ -54,7 +54,7 @@ elif [ "$1" = "console" ]; then
         SERVICE_LIB_CP="console/services/lib/*"
         CLASSPATH="${GRAKN_HOME}/${SERVICE_LIB_CP}:${GRAKN_HOME}/console/conf/"
     # exec replaces current shell process with java so no commands after this one will ever get executed
-        exec java ${CONSOLE_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" grakn.console.GraknConsole "$@"
+        exec java ${CONSOLE_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" grakn.console.GraknConsole "${@:2}"
     else
         echo "Grakn Core Console is not included in this Grakn distribution."
         echo "You may want to install Grakn Core Console or Grakn Core (all)."


### PR DESCRIPTION
## What is the goal of this PR?

Currently there's an off by one bug which causes that `console` (when you run `./grakn console ...`) be thought as the first argument to grakn console. 

