### PR TITLE
Allow grakn_java_test to choose a platform-native Grakn artifact

### DIFF
--- a/test/server/GraknCoreRunner.java
+++ b/test/server/GraknCoreRunner.java
@@ -113,14 +113,19 @@ public class GraknCoreRunner implements GraknRunner {
 
     private void unzip() throws IOException, TimeoutException, InterruptedException {
         System.out.println("Unarchiving Grakn Core distribution");
+        Files.createDirectory(GRAKN_TARGET_DIRECTORY);
         if (GRAKN_DISTRIBUTION_FORMAT.equals(TAR)) {
             executor.command("tar", "-xf", GRAKN_DISTRIBUTION_FILE.toString(),
-                    "-C", GRAKN_TARGET_DIRECTORY.getParent().toString()).execute();
+                    "-C", GRAKN_TARGET_DIRECTORY.toString()).execute();
         } else {
             executor.command("unzip", "-q", GRAKN_DISTRIBUTION_FILE.toString(),
-                    "-d", GRAKN_TARGET_DIRECTORY.getParent().toString()).execute();
+                    "-d", GRAKN_TARGET_DIRECTORY.toString()).execute();
         }
-        executor = executor.directory(GRAKN_TARGET_DIRECTORY.toFile());
+        // The Grakn Core archive extracts to a folder inside GRAKN_TARGET_DIRECTORY named
+        // grakn-core-server-{platform}-{version}. We know it's the only folder, so we can retrieve it using Files.list.
+        final Path graknPath = Files.list(GRAKN_TARGET_DIRECTORY).findFirst().get();
+        System.out.println(graknPath);
+        executor = executor.directory(graknPath.toFile());
 
         System.out.println("Grakn Core distribution unarchived");
     }

--- a/test/server/rules.bzl
+++ b/test/server/rules.bzl
@@ -15,30 +15,23 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-def grakn_test(grakn_artifact = None,
-               deps = [],
-               classpath_resources = [],
-               data = [],
-               **kwargs):
+def grakn_java_test(name, grakn_artifact_linux, grakn_artifact_mac, deps = [], classpath_resources = [], data = [], **kwargs):
 
-    new_data = [] + data
-
-    if grakn_artifact != None:
-        new_data += [grakn_artifact]
-
-    location = "$(location {})".format(grakn_artifact) if grakn_artifact != None else "none"
-
-    native.java_test(
-        deps = depset(deps + [
-            "@graknlabs_common//test/server:grakn-setup",
-        ]).to_list(),
-        classpath_resources = depset(classpath_resources + [
-            "@graknlabs_common//test/server:logback",
-        ]).to_list(),
-        data = depset(new_data).to_list(),
-        args = [
-            location,
-        ],
-        **kwargs
+    native.genrule(
+        name = "grakn_artifact_selector",
+        outs = ["grakn-core-server.tar.gz"],
+        srcs = select({
+            "@graknlabs_dependencies//util/platform:is_mac": [grakn_artifact_mac],
+            "@graknlabs_dependencies//util/platform:is_linux": [grakn_artifact_linux],
+        }, no_match_error = "There is no Grakn Core artifact compatible with this operating system. Supported operating systems are Mac and Linux."),
+        cmd = "read -a srcs <<< '$(SRCS)' && read -a outs <<< '$(OUTS)' && cp $${srcs[0]} $${outs[0]}",
     )
 
+    native.java_test(
+        name = name,
+        deps = depset(deps + ["@graknlabs_common//test/server:grakn-setup"]).to_list(),
+        classpath_resources = depset(classpath_resources + ["@graknlabs_common//test/server:logback"]).to_list(),
+        data = depset(data + ["grakn-core-server.tar.gz"]).to_list(),
+        args = ["$(location grakn-core-server.tar.gz)"],
+        **kwargs
+    )

--- a/test/server/rules.bzl
+++ b/test/server/rules.bzl
@@ -18,8 +18,8 @@
 def grakn_java_test(name, grakn_artifact_linux, grakn_artifact_mac, deps = [], classpath_resources = [], data = [], **kwargs):
 
     native.genrule(
-        name = "grakn_artifact_selector",
-        outs = ["grakn-core-server.tar.gz"],
+        name = "native-grakn-artifact",
+        outs = ["grakn-core-server-native.tar.gz"],
         srcs = select({
             "@graknlabs_dependencies//util/platform:is_mac": [grakn_artifact_mac],
             "@graknlabs_dependencies//util/platform:is_linux": [grakn_artifact_linux],
@@ -31,7 +31,7 @@ def grakn_java_test(name, grakn_artifact_linux, grakn_artifact_mac, deps = [], c
         name = name,
         deps = depset(deps + ["@graknlabs_common//test/server:grakn-setup"]).to_list(),
         classpath_resources = depset(classpath_resources + ["@graknlabs_common//test/server:logback"]).to_list(),
-        data = depset(data + ["grakn-core-server.tar.gz"]).to_list(),
-        args = ["$(location grakn-core-server.tar.gz)"],
+        data = depset(data + [":native-grakn-artifact"]).to_list(),
+        args = ["$(location :native-grakn-artifact)"],
         **kwargs
     )


### PR DESCRIPTION
## What is the goal of this PR?

To allow client-java tests to automatically extract a Grakn Core archive native to the host platform when run.

Previously, they would not - you were stuck with whichever artifact was configured in client-java's `artifacts.bzl`, which was `grakn-core-server-linux`. This would fail to run on a Mac machine.

## What are the changes implemented in this PR?

- Add a `genrule` to `grakn_java_test` that selectively copies the platform-native Grakn artifact to a fixed filename, `grakn-core-server-native.tar.gz`
- Update GraknCoreRunner to specify a fixed folder name to unzip the artifact to, then find the Grakn executable by `cd`-ing to the first folder inside the directory. This isn't ideal, but it works because our Grakn archive contains a single root directory. (Its name varies with the platform and version)
