### PR TITLE
Wait a bit longer for Grakn to start when testing

### DIFF
--- a/test/server/GraknCoreRunner.java
+++ b/test/server/GraknCoreRunner.java
@@ -156,7 +156,7 @@ public class GraknCoreRunner implements GraknRunner {
                     "--data", tmpDir.toAbsolutePath().toString()
             ).start();
 
-            Thread.sleep(5000);
+            Thread.sleep(10000);
             assertTrue("Grakn Core failed to start", graknProcess.getProcess().isAlive());
 
             System.out.println("Grakn Core database server started");


### PR DESCRIPTION
## What is the goal of this PR?

To stabilise the flaky client-java tests.

One of the issues is that Grakn can take up to 9 seconds to start. This causes entire test suites to fail with errors.

## What are the changes implemented in this PR?

Wait a bit longer for Grakn to start when running Java tests (changed from 5 seconds to 10 seconds)
