### PR TITLE
Update collections utils to avoid clashing parameters

### DIFF
--- a/collection/Bytes.java
+++ b/collection/Bytes.java
@@ -46,7 +46,7 @@ public class Bytes {
         return bytes;
     }
 
-    public static String bytesToHexString(final byte[] bytes) {
+    public static String bytesToHexString(byte[] bytes) {
         final char[] hexChars = new char[bytes.length * 2];
         for (int j = 0; j < bytes.length; j++) {
             final int v = bytes[j] & 0xFF;

--- a/collection/Collections.java
+++ b/collection/Collections.java
@@ -63,22 +63,22 @@ public class Collections {
         return java.util.Collections.unmodifiableList(Arrays.asList(elements));
     }
 
-    public static <T> List<T> list(Collection<T> elements) {
+    public static <T> List<T> extend(Collection<T> collection, T... array) {
+        List<T> combined = new ArrayList<>(collection);
+        combined.addAll(Arrays.asList(array));
+        return java.util.Collections.unmodifiableList(combined);
+    }
+
+    public static <T> List<T> copy(Collection<T> elements) {
         List<T> list = new ArrayList<>(elements);
         return java.util.Collections.unmodifiableList(list);
     }
 
-    public static <T> List<T> list(Collection<T>... collections) {
+    public static <T> List<T> concat(Collection<T>... collections) {
         List<T> combined = new ArrayList<>();
         for (Collection<T> collection : collections) {
             combined.addAll(collection);
         }
-        return java.util.Collections.unmodifiableList(combined);
-    }
-
-    public static <T> List<T> list(Collection<T> collection, T... array) {
-        List<T> combined = new ArrayList<>(collection);
-        combined.addAll(Arrays.asList(array));
         return java.util.Collections.unmodifiableList(combined);
     }
 

--- a/collection/Collections.java
+++ b/collection/Collections.java
@@ -59,10 +59,8 @@ public class Collections {
     }
 
     @SafeVarargs
-    public static <T> List<T> list(T element, T... elements) {
-        List<T> list = new ArrayList<>(Arrays.asList(elements));
-        list.add(element);
-        return java.util.Collections.unmodifiableList(list);
+    public static <T> List<T> list(T... elements) {
+        return java.util.Collections.unmodifiableList(Arrays.asList(elements));
     }
 
     public static <T> List<T> list(Collection<T> elements) {
@@ -70,6 +68,7 @@ public class Collections {
         return java.util.Collections.unmodifiableList(list);
     }
 
+    @SafeVarargs
     public static <T> List<T> list(Collection<T> collection1, T item, T... array) {
         List<T> combined = new ArrayList<>(collection1);
         combined.add(item);
@@ -77,6 +76,7 @@ public class Collections {
         return java.util.Collections.unmodifiableList(combined);
     }
 
+    @SafeVarargs
     public static <T> List<T> list(Collection<T> collection, Collection<T>... collections) {
         List<T> combined = new ArrayList<>(collection);
         for (Collection<T> c : collections) {

--- a/collection/Collections.java
+++ b/collection/Collections.java
@@ -59,10 +59,8 @@ public class Collections {
     }
 
     @SafeVarargs
-    public static <T> List<T> list(T element, T... elements) {
-        List<T> list = new ArrayList<>(Arrays.asList(elements));
-        list.add(element);
-        return java.util.Collections.unmodifiableList(list);
+    public static <T> List<T> list(T... elements) {
+        return java.util.Collections.unmodifiableList(Arrays.asList(elements));
     }
 
     public static <T> List<T> list(Collection<T> elements) {

--- a/collection/Collections.java
+++ b/collection/Collections.java
@@ -63,21 +63,22 @@ public class Collections {
         return java.util.Collections.unmodifiableList(Arrays.asList(elements));
     }
 
-    public static <T> List<T> extend(Collection<T> collection, T... array) {
-        List<T> combined = new ArrayList<>(collection);
-        combined.addAll(Arrays.asList(array));
-        return java.util.Collections.unmodifiableList(combined);
-    }
-
-    public static <T> List<T> copy(Collection<T> elements) {
+    public static <T> List<T> list(Collection<T> elements) {
         List<T> list = new ArrayList<>(elements);
         return java.util.Collections.unmodifiableList(list);
     }
 
-    public static <T> List<T> concat(Collection<T>... collections) {
-        List<T> combined = new ArrayList<>();
-        for (Collection<T> collection : collections) {
-            combined.addAll(collection);
+    public static <T> List<T> list(Collection<T> collection1, T item, T... array) {
+        List<T> combined = new ArrayList<>(collection1);
+        combined.add(item);
+        combined.addAll(Arrays.asList(array));
+        return java.util.Collections.unmodifiableList(combined);
+    }
+
+    public static <T> List<T> list(Collection<T> collection, Collection<T>... collections) {
+        List<T> combined = new ArrayList<>(collection);
+        for (Collection<T> c : collections) {
+            combined.addAll(c);
         }
         return java.util.Collections.unmodifiableList(combined);
     }

--- a/collection/Collections.java
+++ b/collection/Collections.java
@@ -59,8 +59,10 @@ public class Collections {
     }
 
     @SafeVarargs
-    public static <T> List<T> list(T... elements) {
-        return java.util.Collections.unmodifiableList(Arrays.asList(elements));
+    public static <T> List<T> list(T element, T... elements) {
+        List<T> list = new ArrayList<>(Arrays.asList(elements));
+        list.add(element);
+        return java.util.Collections.unmodifiableList(list);
     }
 
     public static <T> List<T> list(Collection<T> elements) {


### PR DESCRIPTION
## What is the goal of this PR?
Clarify unmodifiable collections helpers to avoid clashing types. We rename them to both avoid clashing types and make their intention clearer.

## What are the changes implemented in this PR?
* Rename util methods
* Remove `final` in arguments