### PR TITLE
//binary:assemble-linux-apt: adjust path to log dir for Grakn 2.0

### DIFF
--- a/binary/BUILD
+++ b/binary/BUILD
@@ -61,7 +61,7 @@ assemble_apt(
     },
     symlinks = {
         "usr/local/bin/grakn": "/opt/grakn/core/grakn",
-        "opt/grakn/core/logs": "/var/log/grakn/",
+        "opt/grakn/core/server/logs": "/var/log/grakn/",
     },
 )
 


### PR DESCRIPTION
## What is the goal of this PR?

Grakn 2.0 uses a different directory for logs, therefore path for `grakn-bin` APT package needs to be adjusted, relevant config entry is [here](https://github.com/graknlabs/grakn-2.0/blob/e63aa72cc45ba830c9b15b02c760555c40dddd2c/server/conf/grakn.properties#L22).

## What are the changes implemented in this PR?

Adjust package of where logs are stored for APT package
