### PR TITLE
Fix Grakn artifact getting fetched many times when building client

### DIFF
--- a/test/server/logback.xml
+++ b/test/server/logback.xml
@@ -22,7 +22,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/test/server/logback.xml
+++ b/test/server/logback.xml
@@ -22,7 +22,7 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
 


### PR DESCRIPTION
## What is the goal of this PR?

To fix client-java being unable to build in Grabl (failing >70% of the time) due to excess network usage.

## What are the changes implemented in this PR?

We separate out `native_grakn_artifact` so it is no longer defined as part of `grakn_java_test`. Instead, the user is now required to declare a `native_grakn_artifact` in their project, if they want to use it for their `grakn_java_test`s.

As a result, the Grakn artifact ends up being declared in one place and one place only. This is good both on a conceptual level, and practically, because BuildBuddy was uploading the output of every declared Bazel target to a remote server. Given that we have about 32 `grakn_java_test`s in client-java, this meant uploading Grakn 32 times. It is 160MB including both the Linux and Mac distributions, so this was a pretty big hit. It actually made the builds just time out.

The resulting Bazel code on the client side is as follows:

`//test:BUILD`
```python
load("@graknlabs_common//test/server:rules.bzl", "native_grakn_artifact")

native_grakn_artifact(
    name = "native-grakn-artifact",
    mac_artifact = "@graknlabs_grakn_core_artifact_mac//file",
    linux_artifact = "@graknlabs_grakn_core_artifact_linux//file",
    visibility = ["//test:__subpackages__"],
)
```
`//test/behaviour/concept/thing/entity:BUILD`
```python
grakn_java_test(
    name = "test",
    srcs = ["EntityTest.java"],
    test_class = "grakn.client.test.behaviour.concept.thing.entity.EntityTest",
    deps = [ ... ],
    runtime_deps = [ ... ],
    data = ["@graknlabs_behaviour//concept/thing:entity.feature"],
    native_grakn_artifact = "//test:native-grakn-artifact",
    size = "medium",
)
```