### PR TITLE
Upgrade @graknlabs_dependencies to fix dependency-analysis

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -92,7 +92,7 @@ load("//dependencies/maven:artifacts.bzl", graknlabs_common_artifacts = "artifac
 ############################
 
 load("@graknlabs_dependencies//library/maven:rules.bzl", "maven")
-maven(graknlabs_common_artifacts)
+maven(graknlabs_common_artifacts + graknlabs_dependencies_tool_maven_artifacts)
 
 #############################################
 # Generate @graknlabs_common_workspace_refs #

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,5 +21,5 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "a4f56afaacd8d09cc62a6c2fc0fd55718eaa98c2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "ed2c074bea897dada26e4f112c1d08f739e90012", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -1,3 +1,5 @@
+@maven//:com_eclipsesource_minimal_json_minimal_json
+@maven//:com_eclipsesource_minimal_json_minimal_json_0_9_5
 @maven//:com_google_code_findbugs_jsr305
 @maven//:com_google_code_findbugs_jsr305_2_0_2
 @maven//:commons_io_commons_io


### PR DESCRIPTION
## What is the goal of this PR?

Currently, `dependency-analysis` job fails to run `@graknlabs_dependencies//grabl/analysis:dependency-analysis` which happened because of a missing dependency. This is fixed in this PR and graknlabs/dependencies#233

## What are the changes implemented in this PR?

* Upgrade `@graknlabs_dependencies` to current latest `master`
* Load Maven dependencies of `@graknlabs_dependencies//grabl/analysis:dependency-analysis`