### PR TITLE
Fix a the issue where you may get back a null Cancellable from an EventLoop

### DIFF
--- a/concurrent/actor/Actor.java
+++ b/concurrent/actor/Actor.java
@@ -46,7 +46,7 @@ public class Actor<STATE extends Actor.State<STATE>> {
 
     public void tell(Consumer<STATE> job) {
         assert state != null : ERROR_ACTOR_STATE_NOT_SETUP;
-        eventLoop.submit(() -> job.accept(state), state::exception);
+        eventLoop.schedule(() -> job.accept(state), state::exception);
     }
 
     @CheckReturnValue
@@ -61,7 +61,7 @@ public class Actor<STATE extends Actor.State<STATE>> {
     public <ANSWER> CompletableFuture<ANSWER> ask(Function<STATE, ANSWER> job) {
         assert state != null : ERROR_ACTOR_STATE_NOT_SETUP;
         CompletableFuture<ANSWER> future = new CompletableFuture<>();
-        eventLoop.submit(
+        eventLoop.schedule(
                 () -> future.complete(job.apply(state)),
                 e -> {
                     state.exception(e);
@@ -73,7 +73,7 @@ public class Actor<STATE extends Actor.State<STATE>> {
 
     public EventLoop.Cancellable schedule(long deadlineMs, Consumer<STATE> job) {
         assert state != null : ERROR_ACTOR_STATE_NOT_SETUP;
-        return eventLoop.submit(deadlineMs, () -> job.accept(state), state::exception);
+        return eventLoop.schedule(deadlineMs, () -> job.accept(state), state::exception);
     }
 
     public EventLoopGroup eventLoopGroup() {


### PR DESCRIPTION
## What is the goal of this PR?

We have fixed the issue where a race condition may occur when submitting a scheduled job onto the EventLoop.

The race condition is caused by the fact we are returning a reference to a `Cancellable` which may not yet have been created.

The solution is to redesign `Cancellable` such that it can be immediately constructed.

Closes https://github.com/graknlabs/common/issues/66