### PR TITLE
Fix testing rules and runner to work under Windows

### DIFF
--- a/binary/grakn.bat
+++ b/binary/grakn.bat
@@ -54,7 +54,7 @@ goto exiterror
 :startconsole
 
 set "G_CP=%GRAKN_HOME%\console\conf\;%GRAKN_HOME%\console\services\lib\*"
-if exist .\console\services\lib\io-grakn-console-grakn-console-*.jar (
+if exist .\console\ (
   java %CONSOLE_JAVAOPTS% -cp "%G_CP%" -Dgrakn.dir="%GRAKN_HOME%" grakn.console.GraknConsole %2 %3 %4 %5 %6 %7 %8 %9
   goto exit
 ) else (
@@ -66,7 +66,9 @@ if exist .\console\services\lib\io-grakn-console-grakn-console-*.jar (
 :startserver
 
 set "G_CP=%GRAKN_HOME%\server\conf\;%GRAKN_HOME%\server\lib\common\*;%GRAKN_HOME%\server\lib\prod\*"
-if exist .\server\lib\common\io-grakn-core-grakn-server-*.jar (
+
+
+if exist .\server\ (
   java %SERVER_JAVAOPTS% -cp "%G_CP%" -Dgrakn.dir="%GRAKN_HOME%" -Dgrakn.conf="%GRAKN_HOME%\%GRAKN_CONFIG%" grakn.core.server.GraknServer %2 %3 %4 %5 %6 %7 %8 %9
   goto exit
 ) else (

--- a/test/server/GraknCoreRunner.java
+++ b/test/server/GraknCoreRunner.java
@@ -29,6 +29,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Collections;
+import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 
@@ -159,7 +161,7 @@ public class GraknCoreRunner implements GraknRunner {
             System.out.println("Database directory will be at " + tmpDir.toAbsolutePath());
 
             List<String> arguments = new ArrayList<>();
-            arguments.add("./grakn");
+            arguments.addAll(getGraknBinary());
             arguments.add("server");
             if (debug) {
                 arguments.add("--debug");
@@ -170,7 +172,7 @@ public class GraknCoreRunner implements GraknRunner {
             arguments.add(tmpDir.toAbsolutePath().toString());
             graknProcess = executor.command(arguments).start();
 
-            Thread.sleep(10000);
+            Thread.sleep(30000);
             assertTrue("Grakn Core failed to start", graknProcess.getProcess().isAlive());
 
             System.out.println("Grakn Core database server started");
@@ -193,6 +195,10 @@ public class GraknCoreRunner implements GraknRunner {
                 throw e;
             }
         }
+    }
+
+    private List<String> getGraknBinary() {
+        return System.getProperty("os.name").toLowerCase().contains("win") ? Arrays.asList("cmd.exe", "/c", "grakn.bat") : Collections.singletonList("grakn");
     }
 
     private void printLogs() throws InterruptedException, TimeoutException, IOException {

--- a/test/server/rules.bzl
+++ b/test/server/rules.bzl
@@ -16,12 +16,15 @@
 #
 
 def grakn_java_test(name, native_grakn_artifact, deps = [], classpath_resources = [], data = [], **kwargs):
+    native_grakn_artifact_paths = {}
+    for key in native_grakn_artifact.keys():
+        native_grakn_artifact_paths[key] = [ "$(location {})".format(native_grakn_artifact[key]) ]
     native.java_test(
         name = name,
         deps = depset(deps + ["@graknlabs_common//test/server:grakn-setup"]).to_list(),
         classpath_resources = depset(classpath_resources + ["@graknlabs_common//test/server:logback"]).to_list(),
-        data = depset(data + [native_grakn_artifact]).to_list(),
-        args = ["$(location " + native_grakn_artifact + ")"],
+        data = data + select(native_grakn_artifact),
+        args = select(native_grakn_artifact_paths),
         **kwargs
     )
 


### PR DESCRIPTION
## What is the goal of this PR?

Fix the testing infrastructure to allow testing Grakn Core distribution under Windows.

## What are the changes implemented in this PR?

* `grakn_java_test` rule macro no longer accepts `select` and instead takes in the native artifact mapping in this form:
```
native_grakn_artifact = {
    "@graknlabs_dependencies//util/platform:is_mac": "//server:assemble-mac-zip",
    "@graknlabs_dependencies//util/platform:is_linux": "//server:assemble-linux-targz",
    "@graknlabs_dependencies//util/platform:is_windows": "//server:assemble-windows-zip",
}
```

This allow to pass correct path to the platform-specific artifact as test's first argument. More about this approach [here](https://docs.bazel.build/versions/master/configurable-attributes.html#can-i-read-select-like-a-dict).

* `grakn.bat`, the binary script on Windows, now does a simpler check on whether the Console or Server are included in the distribution being ran. This allows the check that previously was false-negative due to long filenames to pass.

* `GraknCoreRunner` now distinguishes platforms and picks the correct binary script (`grakn` vs `grakn.bat`). Additionally, test timeout is increased.