### PR TITLE
Resolve data directory in GraknRunnerBase after distribution has been unpacked

### DIFF
--- a/test/server/GraknRunnerBase.java
+++ b/test/server/GraknRunnerBase.java
@@ -44,7 +44,7 @@ public abstract class GraknRunnerBase implements GraknRunner {
     private final Path distributionDir;
     private final String distributionArchiveFormat;
     protected final int port;
-    protected final Path dataDir;
+    protected Path dataDir;
     protected final boolean debug;
 
     private ProcessExecutor executor;
@@ -71,7 +71,6 @@ public abstract class GraknRunnerBase implements GraknRunner {
         this.distributionArchive = distributionArchive;
         distributionArchiveFormat = distributionFormat(distributionArchive);
         distributionDir = distributionTarget(distributionArchive);
-        dataDir = distributionDir.resolve("server").resolve("data");
         this.debug = debug;
         executor = new ProcessExecutor()
                 .directory(Paths.get(".").toAbsolutePath().toFile())
@@ -79,7 +78,7 @@ public abstract class GraknRunnerBase implements GraknRunner {
                 .redirectError(System.err)
                 .readOutput(true)
                 .destroyOnExit();
-        distributionSetup(distributionDir, dataDir);
+        distributionSetup(distributionDir);
         System.out.println(name() + " runner constructed");
     }
 
@@ -166,9 +165,9 @@ public abstract class GraknRunnerBase implements GraknRunner {
 
     abstract List<String> command();
 
-    private void distributionSetup(Path distributionDir, Path dataDir) throws IOException, TimeoutException, InterruptedException {
+    private void distributionSetup(Path distributionDir) throws IOException, TimeoutException, InterruptedException {
         System.out.println("Unarchiving " + name() + " distribution");
-        Files.createDirectories(dataDir);
+        Files.createDirectories(distributionDir);
         if (distributionArchiveFormat.equals(TAR)) {
             executor.command("tar", "-xf", distributionArchive.toString(),
                     "-C", distributionDir.toString()).execute();
@@ -182,6 +181,7 @@ public abstract class GraknRunnerBase implements GraknRunner {
         System.out.println(graknPath);
         executor = executor.directory(graknPath.toFile());
         System.out.println(name() + " distribution unarchived");
+        dataDir = graknPath.resolve("server").resolve("data");
     }
 
     private void printLogs() {

--- a/test/server/GraknRunnerBase.java
+++ b/test/server/GraknRunnerBase.java
@@ -44,7 +44,7 @@ public abstract class GraknRunnerBase implements GraknRunner {
     private final Path distributionDir;
     private final String distributionArchiveFormat;
     protected final int port;
-    protected Path dataDir;
+    protected final Path dataDir;
     protected final boolean debug;
 
     private ProcessExecutor executor;
@@ -78,7 +78,8 @@ public abstract class GraknRunnerBase implements GraknRunner {
                 .redirectError(System.err)
                 .readOutput(true)
                 .destroyOnExit();
-        distributionSetup(distributionDir);
+        Path graknPath = distributionSetup(distributionDir);
+        dataDir = graknPath.resolve("server").resolve("data");
         System.out.println(name() + " runner constructed");
     }
 
@@ -165,7 +166,7 @@ public abstract class GraknRunnerBase implements GraknRunner {
 
     abstract List<String> command();
 
-    private void distributionSetup(Path distributionDir) throws IOException, TimeoutException, InterruptedException {
+    private Path distributionSetup(Path distributionDir) throws IOException, TimeoutException, InterruptedException {
         System.out.println("Unarchiving " + name() + " distribution");
         Files.createDirectories(distributionDir);
         if (distributionArchiveFormat.equals(TAR)) {
@@ -181,7 +182,7 @@ public abstract class GraknRunnerBase implements GraknRunner {
         System.out.println(graknPath);
         executor = executor.directory(graknPath.toFile());
         System.out.println(name() + " distribution unarchived");
-        dataDir = graknPath.resolve("server").resolve("data");
+        return graknPath;
     }
 
     private void printLogs() {


### PR DESCRIPTION
## What is the goal of this PR?

Fix tests that depend on `GraknCoreRunner`.

## What are the changes implemented in this PR?

Resolve data directory against the unpacked distrubution directory