### PR TITLE
Fix debug mode in grakn start up script

### DIFF
--- a/binary/grakn
+++ b/binary/grakn
@@ -61,7 +61,7 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
     if [[ -d "${GRAKN_HOME}/server" ]]; then
         IDX=0
         while [[ "${@:IDX}" ]]; do
-            case ${@:IDX} in
+            case ${@:IDX:1} in
                 --debug) DEBUG=yes;
                 break;
             esac


### PR DESCRIPTION
## What is the goal of this PR?

Fix an issue causing grakn startup script to disregard the debug mode parameter.

## What are the changes implemented in this PR?

- Use the correct shell parameter expansion to check only a single argument, instead of all remaining arguments. Otherwise `./grakn server --debug --port 1729` will not be considered to be in the debug mode, whereas `./grakn server --debug` will be.