### PR TITLE
Fix grakn debug mode in linux

### DIFF
--- a/binary/grakn
+++ b/binary/grakn
@@ -73,7 +73,8 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
         if [ $DEBUG ]; then
             case "$(uname -s)" in
                 Darwin) CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/dev/*" ;;
-                *) CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/prod/*" && echo "WARNING: Debug mode is not available in this platform." ;;
+                *) echo "WARNING: Debug mode RocksDB is not available in this platform. Fallback to production mode."
+                   CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/prod/*";;
             esac
             exec java ${SERVER_JAVAOPTS} -ea -cp "${CLASSPATH}" \
                 -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" \

--- a/binary/grakn
+++ b/binary/grakn
@@ -73,7 +73,7 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
         if [ $DEBUG ]; then
             case "$(uname -s)" in
                 Darwin) CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/dev/*" ;;
-                *) CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/prod/*" ;;
+                *) CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/prod/*" && echo "WARNING: Debug mode is not available in this platform." ;;
             esac
             exec java ${SERVER_JAVAOPTS} -ea -cp "${CLASSPATH}" \
                 -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" \

--- a/binary/grakn
+++ b/binary/grakn
@@ -71,7 +71,10 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
         CLASSPATH="${GRAKN_HOME}/server/conf/:${GRAKN_HOME}/${LIB_COMMON}"
         # exec replaces current shell process with java so no commands after these ones will ever get executed
         if [ $DEBUG ]; then
-            CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/dev/*"
+            case "$(uname -s)" in
+                Darwin) CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/dev/*"
+                *) CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/prod/*"
+            esac
             exec java ${SERVER_JAVAOPTS} -ea -cp "${CLASSPATH}" \
                 -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" \
                 -Dlogback.configurationFile=logback-debug.xml \

--- a/binary/grakn
+++ b/binary/grakn
@@ -74,7 +74,7 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
             case "$(uname -s)" in
                 Darwin) CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/dev/*" ;;
                 *) echo "WARNING: Debug mode RocksDB is not available in this platform. Fallback to production mode."
-                   CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/prod/*";;
+                   CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/prod/*" ;;
             esac
             exec java ${SERVER_JAVAOPTS} -ea -cp "${CLASSPATH}" \
                 -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" \

--- a/binary/grakn
+++ b/binary/grakn
@@ -72,8 +72,8 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
         # exec replaces current shell process with java so no commands after these ones will ever get executed
         if [ $DEBUG ]; then
             case "$(uname -s)" in
-                Darwin) CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/dev/*"
-                *) CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/prod/*"
+                Darwin) CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/dev/*" ;;
+                *) CLASSPATH="${CLASSPATH}:${GRAKN_HOME}/server/lib/prod/*" ;;
             esac
             exec java ${SERVER_JAVAOPTS} -ea -cp "${CLASSPATH}" \
                 -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" \


### PR DESCRIPTION
## What is the goal of this PR?

Fix Grakn startup script so that it can run with debug flag on Linux, which will fallback to using production version and gives you a warning.

## What are the changes implemented in this PR?

- Since RocksDB dev jar only works on Mac, we disable it on Linux.