### PR TITLE
Fix bug in waiting for server start and stopping server

### DIFF
--- a/test/server/GraknRunner.java
+++ b/test/server/GraknRunner.java
@@ -84,7 +84,7 @@ public abstract class GraknRunner extends Runner {
                 }
                 String lsof;
                 try {
-                    lsof = executor.command("lsof", "-i", ":" + port()).readOutput(true).execute().outputString();
+                    lsof = executor.command("lsof", "-nP", "-iTCP:" + port(), "-sTCP:LISTEN").readOutput(true).execute().outputString();
                 } catch (IOException | InterruptedException | TimeoutException e) {
                     lsof = "";
                 }
@@ -102,7 +102,7 @@ public abstract class GraknRunner extends Runner {
         if (serverProcess != null) {
             try {
                 System.out.println("Stopping " + name() + " database server");
-                serverProcess.getProcess().destroy();
+                serverProcess.getProcess().destroyForcibly();
                 System.out.println(name() + " database server stopped");
             } catch (Exception e) {
                 printLogs();


### PR DESCRIPTION
## What is the goal of this PR?

Fix bug in waiting for server start and stopping server.

## What are the changes implemented in this PR?

- Use the correct `lsof` command to only list listening ports and not converting ports to names.
- Force shutdown server so that we are sure that the server is stopped after the `stop()` returns.
