### PR TITLE
Fix Grakn Cluster runner using invalid ports

### DIFF
--- a/test/server/GraknClusterRunner.java
+++ b/test/server/GraknClusterRunner.java
@@ -41,12 +41,12 @@ public class GraknClusterRunner extends GraknRunner {
         this.peerPorts = peerPorts;
     }
 
-    public GraknClusterRunner(Pair<Integer, Integer> ports) throws InterruptedException, TimeoutException, IOException {
-        this(ports, list(ports));
+    public GraknClusterRunner(Integer port) throws InterruptedException, TimeoutException, IOException {
+        this(pair(port, port + 1), list(pair(port, port + 1)));
     }
 
     public GraknClusterRunner() throws InterruptedException, TimeoutException, IOException {
-        this(pair(ThreadLocalRandom.current().nextInt(40000, 60000), ThreadLocalRandom.current().nextInt(40000)));
+        this(ThreadLocalRandom.current().nextInt(40000, 60000));
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

We fixed a bug where our tests were failing in Cluster because they started up Cluster with invalid port numbers outside the legal range.

## What are the changes implemented in this PR?

Fix Grakn Cluster runner using invalid ports