### PR TITLE
Update the way peers are specified in GraknClusterRunner

### DIFF
--- a/test/server/GraknClusterRunner.java
+++ b/test/server/GraknClusterRunner.java
@@ -66,8 +66,10 @@ public class GraknClusterRunner extends GraknRunner {
         command.add("server");
         command.add("--address");
         command.add(getAddressString(ports));
-        command.add("--peers");
-        command.add(peerPorts.stream().map(this::getAddressString).collect(Collectors.joining(",")));
+        peerPorts.forEach(peerPort -> {
+            command.add("--peer");
+            command.add(getAddressString(peerPort));
+        });
         command.add("--data");
         command.add(dataDir.toAbsolutePath().toString());
         return command;


### PR DESCRIPTION
## What is the goal of this PR?

We've updated`GraknClusterRunner` to reflect the new way that peers are specified.

## What are the changes implemented in this PR?

1. Change the way peers are specified, from this: `--peers=peer1,peer2,peer3` to this: `--peer peer1 --peer peer2 --peer peer3`.