### PR TITLE
Fix ASCII header on Windows

### DIFF
--- a/binary/grakn.bat
+++ b/binary/grakn.bat
@@ -1,4 +1,4 @@
-REM
+@echo off
 REM Copyright (C) 2021 Grakn Labs
 REM
 REM This program is free software: you can redistribute it and/or modify
@@ -14,8 +14,6 @@ REM
 REM You should have received a copy of the GNU Affero General Public License
 REM along with this program.  If not, see <https://www.gnu.org/licenses/>.
 REM
-
-@echo off
 
 SET "GRAKN_HOME=%cd%"
 


### PR DESCRIPTION
## What is the goal of this PR?

Don't print license header when executing `grakn.bat` under Windows

## What are the changes implemented in this PR?

Add `@echo off` such that `cmd.exe` doesn't print out `REM` lines containing license header