### PR TITLE
Tweak location of console libraries

### DIFF
--- a/binary/grakn
+++ b/binary/grakn
@@ -48,7 +48,7 @@ if [ -z "$1" ]; then
     exit 1
 elif [ "$1" = "console" ]; then
     if [ -d "${GRAKN_HOME}/console" ]; then
-        SERVICE_LIB_CP="console/services/lib/*"
+        SERVICE_LIB_CP="console/lib/*"
         CLASSPATH="${GRAKN_HOME}/${SERVICE_LIB_CP}:${GRAKN_HOME}/console/conf/"
     # exec replaces current shell process with java so no commands after this one will ever get executed
         exec java ${CONSOLE_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" grakn.console.GraknConsole "${@:2}"

--- a/binary/grakn.bat
+++ b/binary/grakn.bat
@@ -51,7 +51,7 @@ goto exiterror
 
 :startconsole
 
-set "G_CP=%GRAKN_HOME%\console\conf\;%GRAKN_HOME%\console\services\lib\*"
+set "G_CP=%GRAKN_HOME%\console\conf\;%GRAKN_HOME%\console\lib\*"
 if exist .\console\ (
   java %CONSOLE_JAVAOPTS% -cp "%G_CP%" -Dgrakn.dir="%GRAKN_HOME%" grakn.console.GraknConsole %2 %3 %4 %5 %6 %7 %8 %9
   goto exit


### PR DESCRIPTION
## What is the goal of this PR?

Improve consistency of Grakn Console distribution and help fix an issue with long filenames in the assembled archives.

## What are the changes implemented in this PR?

Move console libraries into `console/lib/`